### PR TITLE
Updates pug to v3.0.2 to address security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "^4.0.0",
     "nib": "~1.1.2",
     "node-redis-warlock": "~0.2.0",
-    "pug": "^2.0.0-beta3",
+    "pug": "3.0.2",
     "redis": "~2.6.0-2",
     "stylus": "~0.54.5",
     "yargs": "^4.0.0"


### PR DESCRIPTION
https://weeverapps.atlassian.net/browse/FM-3070

This addresses GHSA-p493-635q-r6gr by updating the pug dependency. Tests have been run and all pass. I've reviewed the 3.x changes to this dependency and they should not affect how Kue works.

No expected side-effects, this will be then followed up with a PR in Job Worker to point to this version.